### PR TITLE
fix: FRON-76 remove staging branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: ['main', 'staging', 'dev']
+    branches: ['main', 'dev']
   pull_request:
-    branches: ['main', 'staging', 'dev']
+    branches: ['main', 'dev']
   schedule:
     - cron: '26 3 * * 6'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Code Lint and Test
 
 on:
   push:
-    branches: ['main', 'staging', 'dev']
+    branches: ['main', 'dev']
   pull_request:
-    branches: ['main', 'staging', 'dev']
+    branches: ['main', 'dev']
 
 jobs:
   lint:


### PR DESCRIPTION
Removed the staging branch from GitHub workflows together with link and codeql